### PR TITLE
Updated README.md with correction to create_app args

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then try calling some methods:
 ```
 
 ```python
->>> c.create_app(id='myapp3', cmd='sleep 100', mem=16, cpu=1)
+>>> c.create_app(id='myapp3', cmd='sleep 100', mem=16, cpus=1)
 True
 ```
 


### PR DESCRIPTION
the v2/apps post takes a keyword of 'cpus' not 'cpu'.  This example appears to work as the value for cpus defaults to 1.
