### PR TITLE
Bug Fix: Cannot define constraints with a tuple of strings

### DIFF
--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -37,7 +37,9 @@ class MarathonApp(MarathonResource):
     def __init__(self, cmd=None, constraints=None, container=None, cpus=None, env=None, executor=None,
                  health_checks=None, id=None, instances=None, mem=None, ports=None, tasks=None, uris=None):
         self.cmd = cmd
-        self.constraints = constraints or []
+        self.constraints = [
+            c if isinstance(c, MarathonConstraint) else MarathonConstraint(*c)
+            for c in (constraints or [])]
         self.container = container
         self.cpus = cpus
         self.env = env


### PR DESCRIPTION
This PR is a very simple fix.  Currently, if a user attempts to define the following situation:

```
dct = dict(constraints=[['hostname', 'UNIQUE']],    << plus other key:value pairs >> )
client.create_app(**dct)
```

The marathon client raises the following exception:

```
  File "/opt/anaconda/2.0.0/lib/python2.7/site-packages/marathon/client.py", line 88, in create_app
    data = json.dumps(app.json_encode())
  File "/opt/anaconda/2.0.0/lib/python2.7/site-packages/marathon/models/app.py", line 84, in json_encode
    'constraints': [c.json_encode() for c in self.constraints],
AttributeError: 'unicode' object has no attribute 'json_encode'
```
