### PR TITLE
add service_port argument

### DIFF
--- a/marathon/models/container.py
+++ b/marathon/models/container.py
@@ -68,9 +68,10 @@ class MarathonContainerPortMapping(MarathonObject):
     PROTOCOLS=['tcp', 'udp']
     """Valid protocols"""
 
-    def __init__(self, container_port=None, host_port=0, protocol='tcp'):
+    def __init__(self, container_port=None, host_port=0, service_port=None, protocol='tcp'):
         self.container_port = container_port
         self.host_port = host_port
+        self.service_port = service_port
         if not protocol in self.PROTOCOLS:
             raise InvalidChoiceError('protocol', protocol, self.PROTOCOLS)
         self.protocol = protocol


### PR DESCRIPTION
There was a bug when you tried to use the lib to start a docker container in marathon. The problem was that marathon is returning a json field `servicePort` and the code is trying to map it to `service_port` which didn't exists on the `__init__`.

The problem only affected the response parsing, the task in marathon was created fine.

Now I was able to do it like this:

``` python
from marathon import MarathonClient
from marathon.models.container import MarathonContainer, MarathonDockerContainer, MarathonContainerPortMapping

c = MarathonClient('http://localhost:8080/')
ports = MarathonContainerPortMapping(container_port=4444)
docker = MarathonDockerContainer('danielfrg/selenium', network='BRIDGE', port_mappings=[ports])
container = MarathonContainer(docker=docker)
app = MarathonApp(container=container, mem=300, cpus=0.5)
c.create_app('selenium', app)
```

Thanks for the lib :)
