### PR TITLE
Possibility to send the full object to Marathon on update

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -153,7 +153,7 @@ class MarathonClient(object):
         response = self._do_request('GET', '/v2/apps/{app_id}'.format(app_id=app_id), params=params)
         return self._parse_response(response, MarathonApp, resource_name='app')
 
-    def update_app(self, app_id, app, force=False):
+    def update_app(self, app_id, app, force=False, minimal=True):
         """Update an app.
 
         Applies writable settings in `app` to `app_id`
@@ -163,6 +163,7 @@ class MarathonClient(object):
         :param app: application settings
         :type app: :class:`marathon.models.app.MarathonApp`
         :param bool force: apply even if a deployment is in progress
+        :param bool minimal: ignore nulls and empty collections
 
         :returns: a dict containing the deployment id and version
         :rtype: dict
@@ -171,7 +172,7 @@ class MarathonClient(object):
         app.version = None
 
         params = {'force': force}
-        data = app.to_json(minimal=True)
+        data = app.to_json(minimal=minimal)
 
         response = self._do_request('PUT', '/v2/apps/{app_id}'.format(app_id=app_id), params=params, data=data)
         return response.json()
@@ -271,7 +272,7 @@ class MarathonClient(object):
         response = self._do_request('GET', '/v2/groups/{group_id}'.format(group_id=group_id))
         return self._parse_response(response, MarathonGroup, resource_name='group')
 
-    def update_group(self, group_id, group, force=False):
+    def update_group(self, group_id, group, force=False, minimal=True):
         """Update a group.
 
         Applies writable settings in `group` to `group_id`
@@ -281,6 +282,7 @@ class MarathonClient(object):
         :param group: group settings
         :type group: :class:`marathon.models.group.MarathonGroup`
         :param bool force: apply even if a deployment is in progress
+        :param bool minimal: ignore nulls and empty collections
 
         :returns: a dict containing the deployment id and version
         :rtype: dict
@@ -289,7 +291,7 @@ class MarathonClient(object):
         group.version = None
 
         params = {'force': force}
-        data = group.to_json(minimal=True)
+        data = group.to_json(minimal=minimal)
 
         response = self._do_request('PUT', '/v2/groups/{group_id}'.format(group_id=group_id), data=data, params=params)
         return response.json()


### PR DESCRIPTION
Prior to this change setting the value of some keys of an application
(like 'health_checks' or 'constraints') from a collection that contains objects
to an empty collection and then calling `MarathonClient.update_app` to update the
application resulted in health checks or constraints never being updated.

The cause of this was that `MarathonClient.update_app` always called
`app.to_json(minmal=True)` which kicks out all empty collections.

This change lets the developer choose whether `minimal` should be `True` or `False`.
It retains the original behaviour through a default.