### PR TITLE
Quick fix #29 - add kwargs to MarathonDockerContainer.__init__

### DIFF
--- a/marathon/models/container.py
+++ b/marathon/models/container.py
@@ -45,7 +45,7 @@ class MarathonDockerContainer(MarathonObject):
     NETWORK_MODES=['BRIDGE', 'HOST']
     """Valid network modes"""
 
-    def __init__(self, image=None, network='HOST', port_mappings=None, parameters=None, privileged=None):
+    def __init__(self, image=None, network='HOST', port_mappings=None, parameters=None, privileged=None, **kwargs):
         self.image = image
         if network:
             if not network in self.NETWORK_MODES:


### PR DESCRIPTION
I just added **kwargs to `MarathonDockerContainer` constructor so it does not fail when it gets unknown keyword arguments.