### PR TITLE
Add validation to marathon app/group ids

### DIFF
--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from .base import MarathonResource, MarathonObject
+from .base import MarathonResource, MarathonObject, assert_valid_path
 from .constraint import MarathonConstraint
 from .container import MarathonContainer
 from .deployment import MarathonDeployment
@@ -100,7 +100,7 @@ class MarathonApp(MarathonResource):
             hc if isinstance(hc, MarathonHealthCheck) else MarathonHealthCheck().from_json(hc)
             for hc in (health_checks or [])
         ]
-        self.id = id
+        self.id = assert_valid_path(id)
         self.instances = instances
         self.labels = labels or {}
         self.last_task_failure = last_task_failure if (isinstance(last_task_failure, MarathonTaskFailure) or last_task_failure is None) \

--- a/marathon/models/group.py
+++ b/marathon/models/group.py
@@ -1,4 +1,4 @@
-from .base import MarathonResource
+from .base import MarathonResource, assert_valid_id
 from .app import MarathonApp
 
 
@@ -26,5 +26,5 @@ class MarathonGroup(MarathonResource):
             g if isinstance(g, MarathonGroup) else MarathonGroup().from_json(g)
             for g in (groups or [])
         ]
-        self.id = id
+        self.id = assert_valid_id(id)
         self.version = version


### PR DESCRIPTION
Marathon has a strict requirement for what it allows as app/group ids, so let's enforce this in our client models so we can catch validation errors before attempting to upload.

```python
>>> from marathon.models import MarathonApp
>>> MarathonApp(id='foo')
MarathonApp::foo
>>> MarathonApp(id='foo_bar')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "marathon/models/app.py", line 103, in __init__
    self.id = assert_valid_path(id)
  File "marathon/models/base.py", line 72, in assert_valid_path
    raise ValueError('invalid path (allowed: lowercase letters, digits, hyphen, "/", ".", ".."): %r' % path)
ValueError: invalid path (allowed: lowercase letters, digits, hyphen, "/", ".", ".."): 'foo_bar'
>>> MarathonApp(id='foo_bar/fdas')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "marathon/models/app.py", line 103, in __init__
    self.id = assert_valid_path(id)
  File "marathon/models/base.py", line 72, in assert_valid_path
    raise ValueError('invalid path (allowed: lowercase letters, digits, hyphen, "/", ".", ".."): %r' % path)
ValueError: invalid path (allowed: lowercase letters, digits, hyphen, "/", ".", ".."): 'foo_bar/fdas'
>>> MarathonApp(id='foo-bar/fdas')
MarathonApp::foo-bar/fdas
>>> MarathonApp(id='foo-bar/fdas////')
MarathonApp::foo-bar/fdas////
>>> MarathonApp(id='foo-bar/fdas///df/')
MarathonApp::foo-bar/fdas///df/
>>> MarathonApp(id='foo-bar/fdas')
MarathonApp::foo-bar/fdas
>>> from marathon.models import MarathonGroup
>>> MarathonGroup(id='foo-bar/fdas')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "marathon/models/group.py", line 29, in __init__
    self.id = assert_valid_id(id)
  File "marathon/models/base.py", line 86, in assert_valid_id
    raise ValueError('invalid id (allowed: lowercase letters, digits, hyphen, ".", ".."): %r' % id)
ValueError: invalid id (allowed: lowercase letters, digits, hyphen, ".", ".."): 'foo-bar/fdas'
>>> MarathonGroup(id='foo-bar')
MarathonGroup::foo-bar
```