### PR TITLE
First pass at adding an itest framework

### DIFF
--- a/itests/docker-compose.yml
+++ b/itests/docker-compose.yml
@@ -1,0 +1,13 @@
+---
+zookeeper:
+  image: jplock/zookeeper
+  ports:
+    - 2181
+
+marathon:
+  image: mesosphere/marathon:v0.8.1
+  ports:
+    - 8080
+  links:
+    - zookeeper
+  command: '--master local --zk zk://zookeeper:2181/marathon'

--- a/itests/environment.py
+++ b/itests/environment.py
@@ -1,0 +1,21 @@
+import time
+
+from itest_utils import wait_for_marathon
+
+
+def before_all(context):
+    wait_for_marathon()
+
+
+def after_scenario(context, scenario):
+    """If a marathon client object exists in our context, delete any apps in Marathon and wait until they die."""
+    if context.client:
+        while True:
+            apps = context.client.list_apps()
+            if not apps:
+                break
+            for app in apps:
+                context.client.delete_app(app.id, force=True)
+            time.sleep(0.5)
+        while context.client.list_deployments():
+            time.sleep(0.5)

--- a/itests/itest_utils.py
+++ b/itests/itest_utils.py
@@ -1,0 +1,74 @@
+import errno
+from functools import wraps
+import os
+import signal
+import sys
+import threading
+import time
+
+import requests
+from compose.cli import command
+
+
+class TimeoutError(Exception):
+    pass
+
+def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
+    def decorator(func):
+        def _handle_timeout(signum, frame):
+            raise TimeoutError(error_message)
+
+        def wrapper(*args, **kwargs):
+            signal.signal(signal.SIGALRM, _handle_timeout)
+            signal.alarm(seconds)
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+            return result
+
+        return wraps(func)(wrapper)
+
+    return decorator
+
+
+@timeout(10)
+def wait_for_marathon():
+    """Blocks until marathon is up"""
+    marathon_service = get_service_connection_string('marathon')
+    while True:
+        print 'Connecting to marathon on %s' % marathon_service
+        try:
+            response = requests.get('http://%s/ping' % marathon_service, timeout=2)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ):
+            time.sleep(2)
+            continue
+        if response.status_code == 200:
+            print "Marathon is up and running!"
+            break
+
+
+def get_compose_service(service_name):
+    """Returns a compose object for the service"""
+    cmd = command.Command()
+    project = cmd.get_project(cmd.get_config_path())
+    return project.get_service(service_name)
+
+
+def get_service_connection_string(service_name):
+    """Given a container name this function returns
+    the host and ephemeral port that you need to use to connect to. For example
+    if you are spinning up a 'web' container that inside listens on 80, this
+    function would return 0.0.0.0:23493 or whatever ephemeral forwarded port
+    it has from docker-compose"""
+    service_port = get_service_internal_port(service_name)
+    return get_compose_service(service_name).get_container().get_local_port(service_port)
+
+
+def get_service_internal_port(service_name):
+    """Gets the exposed port for service_name from docker-compose.yml. If there are
+    multiple ports. It returns the first one."""
+    return get_compose_service(service_name).options['ports'][0]

--- a/itests/marathon_python.feature
+++ b/itests/marathon_python.feature
@@ -1,0 +1,6 @@
+Feature: marathon-python can create and list marathon apps
+
+  Scenario: Trivial apps can be deployed
+    Given a working marathon instance
+    When we create a trivial new app
+    Then we should see it running via the marathon api

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -1,0 +1,31 @@
+import sys
+import time
+
+import marathon
+from behave import given, when, then
+import mock
+
+from itest_utils import get_service_connection_string
+sys.path.append('../')
+
+
+@given('a working marathon instance')
+def working_marathon(context):
+    """Adds a working marathon client as context.client for the purposes of
+    interacting with it in the test."""
+    if not hasattr(context, 'client'):
+        marathon_connection_string = "http://%s" % \
+            get_service_connection_string('marathon')
+        context.client = marathon.MarathonClient(marathon_connection_string)
+
+
+@when(u'we create a trivial new app')
+def create_trivial_new_app(context):
+    context.client.create_app('myapp3', marathon.MarathonApp(cmd='sleep 100', mem=16, cpus=1))
+
+
+@then(u'we should see it running via the marathon api')
+def see_it_running(context):
+    print(context.client.list_apps())
+    assert context.client.get_app('myapp3')
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+usedevelop=True
+basepython = python2.7
+envlist = py
+
+[testenv:marathon_integration]
+basepython = python2.7
+skipsdist=True
+changedir=itests/
+deps =
+    docker-compose
+    behave
+    mock
+commands =
+    docker-compose pull
+    docker-compose up -d
+    behave {posargs}
+    docker-compose stop
+    docker-compose rm --force


### PR DESCRIPTION
Often when working with upgrades and stuff, we see breaking changes with the python bindings as the API changes.

That is fine, but now do we *know* what to add or when a version bump will be incompatible?

At Yelp we use docker-compose and behave to do our testing, I would like to transplant some of the infrastructure into here so everyone can see together when things break, and how.

If accepted, I'll do a second pass add travis integration, bump the version of marathon we are testing against, and then add more tests besides the trivial one.
(the most recent breakage was having the python bindings list an app that had fancy healthchecks, so I would add a test for that)

cc @ConnorDoyle @mrtyler @evankrall

Here is what the output looks like:
```
tox -e marathon_integration -r
GLOB sdist-make: /home/kwa/Projects/marathon-python/setup.py
marathon_integration recreate: /home/kwa/Projects/marathon-python/.tox/marathon_integration
marathon_integration installdeps: docker-compose, behave, mock
marathon_integration inst: /home/kwa/Projects/marathon-python/.tox/dist/marathon-0.6.15.zip
marathon_integration runtests: PYTHONHASHSEED='1571257487'
marathon_integration runtests: commands[0] | docker-compose pull
Pulling zookeeper (jplock/zookeeper:latest)...
Pulling repository jplock/zookeeper
9ce81845fa8f: Download complete
8dbd9e392a96: Download complete
08da2253f1aa: Download complete
d2249a076ab6: Download complete
8bc678765bbf: Download complete
6ea205787f72: Download complete
8d84b0f60499: Download complete
4e575f42d2ea: Download complete
1a31ff0ae6e1: Download complete
285eb269c2ab: Download complete
0d18cf8f8d7f: Download complete
9e139a0c714e: Download complete
8c2cb49d8659: Download complete
Status: Image is up to date for jplock/zookeeper:latest
Pulling marathon (mesosphere/marathon:v0.8.1)...
v0.8.1: Pulling from mesosphere/marathon
428b411c28f0: Already exists
435050075b3f: Already exists
9fd3c8c9af32: Already exists
6d4946999d4f: Already exists
193a5985f612: Already exists
dacae11ddf99: Already exists
4188e38c5565: Already exists
82e78910a7d9: Already exists
95028e8de9ec: Already exists
a9a0baf0f2e4: Already exists
5903e8a575e4: Already exists
Digest: sha256:acb57ad6bacebc9ad842a752679cf8d7321d3261794561a1ea8806c1e9bf241a
Status: Image is up to date for mesosphere/marathon:v0.8.1
marathon_integration runtests: commands[1] | docker-compose up -d
Creating itests_zookeeper_1...
Creating itests_marathon_1...
marathon_integration runtests: commands[2] | behave
Connecting to marathon on 0.0.0.0:32841
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
Connecting to marathon on 0.0.0.0:32841
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
Connecting to marathon on 0.0.0.0:32841
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
Marathon is up and running!
Feature: marathon-python can create and list marathon apps # marathon_python.feature:1

  Scenario: Trivial apps can be deployed               # marathon_python.feature:3
    Given a working marathon instance                  # steps/marathon_steps.py:12 0.008s
    When we create a trivial new app                   # steps/marathon_steps.py:22
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
    When we create a trivial new app                   # steps/marathon_steps.py:22 0.543s
    Then we should see it running via the marathon api # steps/marathon_steps.py:27
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
INFO:marathon:Got response from http://0.0.0.0:32841
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
    Then we should see it running via the marathon api # steps/marathon_steps.py:27 0.090s
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
INFO:marathon:Got response from http://0.0.0.0:32841
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
INFO:marathon:Got response from http://0.0.0.0:32841
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
INFO:marathon:Got response from http://0.0.0.0:32841
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 0.0.0.0
INFO:marathon:Got response from http://0.0.0.0:32841

1 feature passed, 0 failed, 0 skipped
1 scenario passed, 0 failed, 0 skipped
3 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m0.642s
_________________________________________________________________________ summary __________________________________________________________________________
  marathon_integration: commands succeeded
  congratulations :)
```