### PR TITLE
Added failing test and fix for unicode handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ env:
 # - MARATHONVERSION: 0.9.0
 
 language: python
-python: 2.7
+python:
+  - 2.7
+  - 3.4
 sudo: true
 install:
   - pip install tox

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -25,16 +25,16 @@ def create_trivial_new_app(context):
 
 
 @when(u'we create a complex new app')
-def create_complex_new_app(context):
+def create_complex_new_app_with_unicode(context):
     app_config = {
         'container': {
             'type': 'DOCKER',
             'docker': {
                 'portMappings': [{'protocol': 'tcp', 'containerPort': 8888, 'hostPort': 0}],
-                'image': 'localhost/fake_docker_url',
+                'image': u'localhost/fake_docker_url',
                 'network': 'BRIDGE',
             },
-            'volumes': [{'hostPath': '/etc/stuff', 'containerPath': '/etc/stuff', 'mode': 'RO'}],
+            'volumes': [{'hostPath': u'/etc/stuff', 'containerPath': u'/etc/stuff', 'mode': 'RO'}],
         },
         'instances': 1,
         'mem': 30,
@@ -44,7 +44,7 @@ def create_complex_new_app(context):
         'uris': ['file:///root/.dockercfg'],
         'backoff_seconds': 1,
         'constraints': None,
-        'cmd': '/bin/true',
+        'cmd': u'/bin/true',
         'health_checks': [
             {
                 'protocol': 'HTTP',

--- a/marathon/util.py
+++ b/marathon/util.py
@@ -9,6 +9,10 @@ except ImportError:
 import re
 
 
+def is_stringy(obj):
+    return isinstance(obj, str) or isinstance(obj, unicode)
+
+
 class MarathonJsonEncoder(json.JSONEncoder):
     """Custom JSON encoder for Marathon object serialization."""
 
@@ -19,7 +23,7 @@ class MarathonJsonEncoder(json.JSONEncoder):
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
 
-        if isinstance(obj, collections.Iterable) and not isinstance(obj, str):
+        if isinstance(obj, collections.Iterable) and not is_stringy(obj):
             try:
                 return {k: self.default(v) for k,v in obj.items()}
             except AttributeError:
@@ -38,7 +42,7 @@ class MarathonMinimalJsonEncoder(json.JSONEncoder):
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
 
-        if isinstance(obj, collections.Iterable) and not isinstance(obj, str):
+        if isinstance(obj, collections.Iterable) and not is_stringy(obj):
             try:
                 return {k: self.default(v) for k,v in obj.items() if (v or v == False)}
             except AttributeError:


### PR DESCRIPTION
This caused issues for us described in #50.

This fix makes the json decoder assume that `str` and `unicode` objects should both be treated "as strings"

cc @kevinschoon 

cc @evankrall @mrtyler