### PR TITLE
Provide proper compatability support for str/unicode in py3

### DIFF
--- a/marathon/_compat.py
+++ b/marathon/_compat.py
@@ -1,0 +1,11 @@
+"""
+Support for python 2 & 3, ripped pieces from six.py
+"""
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    string_types = str,
+else:
+    string_types = basestring,

--- a/marathon/client.py
+++ b/marathon/client.py
@@ -1,20 +1,10 @@
 import itertools
 import time
-import sys
 
 try:
     import json
 except ImportError:
     import simplejson as json
-
-# Support Python 2 & 3
-
-if sys.version_info[0] == 3:
-    import urllib.parse as urlparse
-    from urllib.error import HTTPError
-else:
-    import urlparse
-    from urllib2 import HTTPError
 
 import requests
 import requests.exceptions

--- a/marathon/util.py
+++ b/marathon/util.py
@@ -1,6 +1,5 @@
 import collections
 import datetime
-import types
 
 try:
     import json
@@ -8,9 +7,11 @@ except ImportError:
     import simplejson as json
 import re
 
+from ._compat import string_types
+
 
 def is_stringy(obj):
-    return isinstance(obj, str) or isinstance(obj, unicode)
+    return isinstance(obj, string_types)
 
 
 class MarathonJsonEncoder(json.JSONEncoder):
@@ -25,7 +26,7 @@ class MarathonJsonEncoder(json.JSONEncoder):
 
         if isinstance(obj, collections.Iterable) and not is_stringy(obj):
             try:
-                return {k: self.default(v) for k,v in obj.items()}
+                return {k: self.default(v) for k, v in obj.items()}
             except AttributeError:
                 return [self.default(e) for e in obj]
 
@@ -44,9 +45,9 @@ class MarathonMinimalJsonEncoder(json.JSONEncoder):
 
         if isinstance(obj, collections.Iterable) and not is_stringy(obj):
             try:
-                return {k: self.default(v) for k,v in obj.items() if (v or v == False)}
+                return {k: self.default(v) for k, v in obj.items() if (v or v is False)}
             except AttributeError:
-                return [self.default(e) for e in obj if (e or e == False)]
+                return [self.default(e) for e in obj if (e or e is False)]
 
         return obj
 


### PR DESCRIPTION
Fixes bug introduced with ae6763af1f91f2d35aa3ff238c77500dfb6caab0
Also cleans up a few lint issues and unused imports

`unicode` yields a `NameError` in py3.