### PR TITLE
Remove call to logging.basicConfig

### DIFF
--- a/marathon/__init__.py
+++ b/marathon/__init__.py
@@ -5,4 +5,3 @@ from .models import MarathonResource, MarathonApp, MarathonTask, MarathonConstra
 from .exceptions import MarathonError, MarathonHttpError, NotFoundError, InvalidChoiceError
 
 log = logging.getLogger(__name__)
-logging.basicConfig()


### PR DESCRIPTION
It's rude to interfere with the using application logging configuration...

See [this](http://pythonsweetness.tumblr.com/post/67394619015/use-of-logging-package-from-within-a-library) about "explicitly configuring handlers", which is what `basicConfig` does.

The effect in my application is that it adds a handler to my already existing handlers, causing duplicate output to the console in a way I cannot control.