### PR TITLE
Use the /v2/tasks/delete endpoint for taskkill

### DIFF
--- a/itests/marathon_apps.feature
+++ b/itests/marathon_apps.feature
@@ -8,7 +8,6 @@ Feature: marathon-python can create and list marathon apps
     Given a working marathon instance
      When we create a trivial new app
      Then we should see the trivial app running via the marathon api
-      And we should be able to kill the tasks
 
  Scenario: Complex apps can be deployed
     Given a working marathon instance

--- a/itests/marathon_tasks.feature
+++ b/itests/marathon_tasks.feature
@@ -1,0 +1,13 @@
+Feature: marathon-python can operate marathon app tasks
+
+  Scenario: App tasks can be killed
+    Given a working marathon instance
+     When we create a trivial new app
+      And we wait the trivial app deployment finish
+     Then we should be able to kill the tasks
+
+  Scenario: A list of app tasks can be killed
+    Given a working marathon instance
+     When we create a trivial new app
+      And we wait the trivial app deployment finish
+     Then we should be able to kill the #0,1,2 tasks of the trivial app

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -25,7 +25,7 @@ def get_marathon_info(context):
 
 @when(u'we create a trivial new app')
 def create_trivial_new_app(context):
-    context.client.create_app('test-trivial-app', marathon.MarathonApp(cmd='sleep 100', mem=16, cpus=1))
+    context.client.create_app('test-trivial-app', marathon.MarathonApp(cmd='sleep 3600', mem=16, cpus=1, instances=5))
 
 
 @then(u'we should be able to kill the tasks')
@@ -76,3 +76,22 @@ def create_complex_new_app_with_unicode(context):
 def see_complext_app_running(context, which):
     print(context.client.list_apps())
     assert context.client.get_app('test-%s-app' % which)
+
+
+@when(u'we wait the {which} app deployment finish')
+def wait_deployment_finish(context, which):
+    while True:
+        time.sleep(1)
+        app = context.client.get_app('test-%s-app' % which, embed_tasks=True)
+        if not app.deployments:
+            break
+
+
+@then(u'we should be able to kill the #{to_kill} tasks of the {which} app')
+def kill_tasks(context, to_kill, which):
+    app_tasks = context.client.get_app('test-%s-app' % which, embed_tasks=True).tasks
+
+    index_to_kill = eval("[" + to_kill + "]")
+    task_to_kill = [app_tasks[index].id for index in index_to_kill]
+
+    context.client.kill_given_tasks(task_to_kill)

--- a/marathon/client.py
+++ b/marathon/client.py
@@ -350,6 +350,20 @@ class MarathonClient(object):
 
         return tasks
 
+    def kill_given_tasks(self, task_ids, scale=False):
+        """Kill a list of given tasks.
+
+        :param list[str] task_ids: tasks to kill
+        :param bool scale: if true, scale down the app by the number of tasks killed
+
+        :return: True on success
+        :rtype: bool
+        """
+        params = {'scale': scale}
+        data = json.dumps({"ids": task_ids})
+        response = self._do_request('POST', '/v2/tasks/delete', params=params, data=data)
+        return response == 200
+
     def kill_tasks(self, app_id, scale=False, host=None, batch_size=0, batch_delay=0):
         """Kill all tasks belonging to app.
 


### PR DESCRIPTION
Implement this:
https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-tasks-delete

In fact, as function name `kill_task` and `kill_tasks` both occupied, I'm not sure how to name it.