### PR TITLE
Modify list_apps so user can input app_id without the starting slash

### DIFF
--- a/itests/marathon_tasks.feature
+++ b/itests/marathon_tasks.feature
@@ -1,5 +1,11 @@
 Feature: marathon-python can operate marathon app tasks
 
+  Scenario: App tasks can be listed
+    Given a working marathon instance
+     When we create a trivial new app
+      And we wait the trivial app deployment finish
+     Then we should be able to list tasks of the trivial app
+
   Scenario: App tasks can be killed
     Given a working marathon instance
      When we create a trivial new app

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -95,3 +95,10 @@ def kill_tasks(context, to_kill, which):
     task_to_kill = [app_tasks[index].id for index in index_to_kill]
 
     context.client.kill_given_tasks(task_to_kill)
+
+
+@then(u'we should be able to list tasks of the {which} app')
+def list_tasks(context, which):
+    app = context.client.get_app('test-%s-app' % which)
+    tasks = context.client.list_tasks('test-%s-app' % which)
+    assert len(tasks) == app.instances

--- a/marathon/client.py
+++ b/marathon/client.py
@@ -342,7 +342,7 @@ class MarathonClient(object):
         response = self._do_request('GET', '/v2/tasks')
         tasks = self._parse_response(response, MarathonTask, is_list=True, resource_name='tasks')
         if app_id:
-            tasks = [task for task in tasks if task.app_id == app_id]
+            tasks = [task for task in tasks if task.app_id.lstrip('/') == app_id.lstrip('/')]
 
         [setattr(t, 'app_id', app_id) for t in tasks if app_id and t.app_id is None]
         for k, v in kwargs.items():


### PR DESCRIPTION
I want to write code like `client.list_tasks("my-test-app")` to get task list, but by now i get an empty list