### PR TITLE
Added tests for killing tasks on an app

### DIFF
--- a/itests/Dockerfile
+++ b/itests/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:webupd8team/java
 RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
-RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer java8-runtime-headless
+RUN apt-get update && apt-get -y install lsb-release oracle-java8-installer
 
 # Setup
 ADD ./marathon-version /root/marathon-version

--- a/itests/marathon_python.feature
+++ b/itests/marathon_python.feature
@@ -2,14 +2,15 @@ Feature: marathon-python can create and list marathon apps
 
   Scenario: Metadata can be fetched
     Given a working marathon instance
-    Then we get the marathon instance's info
+     Then we get the marathon instance's info
 
   Scenario: Trivial apps can be deployed
     Given a working marathon instance
-    When we create a trivial new app
-    Then we should see the trivial app running via the marathon api
+     When we create a trivial new app
+     Then we should see the trivial app running via the marathon api
+      And we should be able to kill the tasks
 
  Scenario: Complex apps can be deployed
     Given a working marathon instance
-    When we create a complex new app
-    Then we should see the complex app running via the marathon api
+     When we create a complex new app
+     Then we should see the complex app running via the marathon api

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -3,7 +3,6 @@ import time
 
 import marathon
 from behave import given, when, then
-import mock
 
 from itest_utils import get_marathon_connection_string
 sys.path.append('../')
@@ -27,6 +26,14 @@ def get_marathon_info(context):
 @when(u'we create a trivial new app')
 def create_trivial_new_app(context):
     context.client.create_app('test-trivial-app', marathon.MarathonApp(cmd='sleep 100', mem=16, cpus=1))
+
+
+@then(u'we should be able to kill the tasks')
+def kill_a_task(context):
+    time.sleep(5)
+    app = context.client.get_app('test-trivial-app')
+    tasks = app.tasks
+    context.client.kill_task(app_id='test-trivial-app', task_id=tasks[0].id, scale=True)
 
 
 @when(u'we create a complex new app')

--- a/marathon/client.py
+++ b/marathon/client.py
@@ -373,14 +373,13 @@ class MarathonClient(object):
             params = {'scale': scale}
             if host: params['host'] = host
             response = self._do_request('DELETE', '/v2/apps/{app_id}/tasks'.format(app_id=app_id), params)
-            try:
+            # Marathon is inconsistent about what type of object it returns on the multi
+            # task deletion endpoint, depending on the version of Marathon. See:
+            # https://github.com/mesosphere/marathon/blob/06a6f763a75fb6d652b4f1660685ae234bd15387/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala#L88-L95
+            if response.json().has_key("tasks"):
                 return self._parse_response(response, MarathonTask, is_list=True, resource_name='tasks')
-            except KeyError:
-                # Marathon is inconsistent about what type of object it returns on the multi
-                # task deletion endpoint, depending on the version of Marathon. See:
-                # https://github.com/mesosphere/marathon/blob/06a6f763a75fb6d652b4f1660685ae234bd15387/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala#L88-L95
-                # TODO: Parse as a deployment if scale==True when only supporting Marathon >=0.11
-                return None
+            else:
+                return response.json()
         else:
             # Terminate in batches
             tasks = self.list_tasks(app_id, host=host) if host else self.list_tasks(app_id)
@@ -419,14 +418,13 @@ class MarathonClient(object):
         params = {'scale': scale}
         response = self._do_request('DELETE', '/v2/apps/{app_id}/tasks/{task_id}'
                                     .format(app_id=app_id, task_id=task_id), params)
-        try:
-            return self._parse_response(response, MarathonTask, resource_name='task')
-        except KeyError:
-            # Marathon is inconsistent about what type of object it returns on the single
-            # task deletion endpoint, depending on the version of Marathon. See:
-            # https://github.com/mesosphere/marathon/blob/06a6f763a75fb6d652b4f1660685ae234bd15387/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala#L112-L119
-            # TODO: Parse as a deployment if scale==True when only supporting Marathon >=0.11
-            return None
+        # Marathon is inconsistent about what type of object it returns on the multi
+        # task deletion endpoint, depending on the version of Marathon. See:
+        # https://github.com/mesosphere/marathon/blob/06a6f763a75fb6d652b4f1660685ae234bd15387/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala#L88-L95
+        if response.json().has_key("task"):
+            return self._parse_response(response, MarathonTask, is_list=False, resource_name='task')
+        else:
+            return response.json()
 
     def list_versions(self, app_id):
         """List the versions of an app.


### PR DESCRIPTION
It looks like these python bindings can't `kill_task` properly on Marathon 11, but they can on Marathon 8.

This is a WIP to add a failing test to catch this, and then hopefully add a fix.

cc @Rob-Johnson  @EvanKrall