### PR TITLE
Release 0.7.5 for official Marathon 11 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Change Log
 
+## [Unreleased](https://github.com/thefactory/marathon-python/tree/HEAD)
+
+[Full Changelog](https://github.com/thefactory/marathon-python/compare/0.7.4...HEAD)
+
+**Merged pull requests:**
+
+- Added tests for killing tasks on an app [\#72](https://github.com/thefactory/marathon-python/pull/72) ([solarkennedy](https://github.com/solarkennedy))
+- Provide proper compatability support for str/unicode in py3 [\#57](https://github.com/thefactory/marathon-python/pull/57) ([mattrobenolt](https://github.com/mattrobenolt))
+
 ## [0.7.4](https://github.com/thefactory/marathon-python/tree/0.7.4) (2015-11-20)
 [Full Changelog](https://github.com/thefactory/marathon-python/compare/0.7.3...0.7.4)
 
 **Merged pull requests:**
 
+- Use automatic changelog generation [\#69](https://github.com/thefactory/marathon-python/pull/69) ([solarkennedy](https://github.com/solarkennedy))
 - Marathon 11 Support [\#68](https://github.com/thefactory/marathon-python/pull/68) ([solarkennedy](https://github.com/solarkennedy))
 
 ## [0.7.3](https://github.com/thefactory/marathon-python/tree/0.7.3) (2015-11-12)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This is a Python library for interfacing with [Marathon](https://github.com/meso
 
 marathon-python is primarily developed against Marathon 0.8.x (see [Marathon docs](https://mesosphere.github.io/marathon/))
 
-* For Marathon 0.8.x-0.9.x, use the latest release
+* For Marathon greater than 0.11.x: Not supported yet. Please submit a patch!
+* For Marathon 0.8.x-0.11.x, use marathon-python 0.7.5
+* For Marathon 0.8.x-0.9.x, use marathon-python 0.6.11 - 0.7.4
 * For Marathon 0.7.x, use marathon-python 0.6.10
-* For older versions, please see `CHANGELOG.md`
+* For all version changes, please see `CHANGELOG.md`
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3,):
 
 setup(
     name='marathon',
-    version='0.7.4',
+    version='0.7.5',
     description='Marathon Client Library',
     long_description="""Python interface to the Mesos Marathon REST API.""",
     author='Mike Babineau',


### PR DESCRIPTION
This is me releasing a new version and documenting in the readme which versions of Marathon are supported, etc. If ship it I'll also tag and release to pypi. (and maybe I'll setup automatic pypi promotion?)