### PR TITLE
Support the deployments endpoint correctly in marathon 1.1.1

### DIFF
--- a/itests/marathon_deployments.feature
+++ b/itests/marathon_deployments.feature
@@ -1,0 +1,6 @@
+Feature: marathon-python read deployments
+
+  Scenario: deployments can be read
+    Given a working marathon instance
+     When we create a trivial new app
+     Then we should be able to see a deployment

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -158,4 +158,4 @@ def stop_listening_stream(context):
 
 @then('we should be able to see a deployment')
 def see_a_deployment(context):
-    assert len(context.client.list_deployments() == 1)
+    assert len(context.client.list_deployments()) == 1

--- a/itests/steps/marathon_steps.py
+++ b/itests/steps/marathon_steps.py
@@ -155,3 +155,7 @@ def stop_listening_stream(context):
     # and 2 deployment_step_success events
     filtered_events = [e for e in context.events if e.event_type == "deployment_success"]
     assert len(filtered_events) == 2
+
+@then('we should be able to see a deployment')
+def see_a_deployment(context):
+    assert len(context.client.list_deployments() == 1)

--- a/marathon/models/__init__.py
+++ b/marathon/models/__init__.py
@@ -1,7 +1,7 @@
 from .app import MarathonApp, MarathonHealthCheck
 from .base import MarathonResource, MarathonObject
 from .constraint import MarathonConstraint
-from .deployment import MarathonDeployment, MarathonDeploymentAction
+from .deployment import MarathonDeployment, MarathonDeploymentAction, MarathonDeploymentStep
 from .endpoint import MarathonEndpoint
 from .group import MarathonGroup
 from .info import MarathonInfo, MarathonConfig, MarathonZooKeeperConfig

--- a/marathon/models/base.py
+++ b/marathon/models/base.py
@@ -9,7 +9,7 @@ class MarathonObject(object):
     """Base Marathon object."""
 
     def __repr__(self):
-        return "{clazz}::{obj}".format(clazz=self.__class__.__name__, obj=self.to_json())
+        return "{clazz}::{obj}".format(clazz=self.__class__.__name__, obj=self.to_json(minimal=False))
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/marathon/models/deployment.py
+++ b/marathon/models/deployment.py
@@ -40,7 +40,7 @@ class MarathonDeployment(MarathonResource):
             return MarathonDeploymentStep().from_json(step)
         elif step.__class__ == list:
             # This is Marathon < 1.0.0 style, a list of actions
-            return [MarathonDeploymentAction().from_json(s) for s in step]
+            return [s if isinstance(s, MarathonDeploymentAction) else MarathonDeploymentAction().from_json(s) for s in step]
         else:
             return step
 
@@ -78,7 +78,7 @@ class MarathonDeploymentPlan(MarathonObject):
 class MarathonDeploymentStep(MarathonObject):
 
     def __init__(self, actions=None):
-        self.actions = [MarathonDeploymentAction.from_json(x) for x in (actions or [])]
+        self.actions = [a if isinstance(a, MarathonDeploymentAction) else MarathonDeploymentAction.from_json(a) for a in (actions or [])]
 
 
 class MarathonDeploymentOriginalState(MarathonObject):

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
   pytest
   mock
 commands =
-  py.test -s {posargs:tests}
+  py.test -s -vv {posargs:tests}
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
Primary: @Rob-Johnson 

My previous PR (https://github.com/thefactory/marathon-python/pull/92) lacked support for the `deployments` endpoint. It wasn't really under test.

This PR adds support for the new and old formats, and adds itests and unit tests for both.

We caught this because our paasta itests interacted with the deployments endpoint and were failing.


This was particularly hard for me because I'm an OOP noob. Special thanks to @mjksmith for pairing with me to get this right.

If shipit I'll merge it in and update the readme/release because deployments support for 1.0 is broken right now.