### PR TITLE
Added force option for kill_given_tasks

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -412,16 +412,19 @@ class MarathonClient(object):
 
         return tasks
 
-    def kill_given_tasks(self, task_ids, scale=False):
+    def kill_given_tasks(self, task_ids, scale=False, force=None):
         """Kill a list of given tasks.
 
         :param list[str] task_ids: tasks to kill
         :param bool scale: if true, scale down the app by the number of tasks killed
+        :param bool force: if true, ignore any current running deployments
 
         :return: True on success
         :rtype: bool
         """
         params = {'scale': scale}
+        if force is not None:
+            params['force'] = force
         data = json.dumps({"ids": task_ids})
         response = self._do_request(
             'POST', '/v2/tasks/delete', params=params, data=data)


### PR DESCRIPTION
This adds an optional `force` option to the kill_given_tasks function.

I left it as optional (`None`) because this is undocumented and not backwards compatible with old versions of marathon.