### PR TITLE
Change to_json() datatime format

### DIFF
--- a/marathon/util.py
+++ b/marathon/util.py
@@ -23,7 +23,7 @@ class MarathonJsonEncoder(json.JSONEncoder):
             return self.default(obj.json_repr())
 
         if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
+            return obj.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         if isinstance(obj, collections.Iterable) and not is_stringy(obj):
             try:
@@ -43,7 +43,7 @@ class MarathonMinimalJsonEncoder(json.JSONEncoder):
             return self.default(obj.json_repr(minimal=True))
 
         if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
+            return obj.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         if isinstance(obj, collections.Iterable) and not is_stringy(obj):
             try:


### PR DESCRIPTION
As the time format that MarathonApp.to_json() and MarathonApp.from_json() used is different, so the json dumped by to_json() can not be loaded by frmo_json().

This commit will use unify time format for both method.