### PR TITLE
Issue110: MarathonTask.ip_addresses attribute is set properly

### DIFF
--- a/marathon/models/task.py
+++ b/marathon/models/task.py
@@ -44,7 +44,18 @@ class MarathonTask(MarathonResource):
         self.started_at = started_at if (started_at is None or isinstance(started_at, datetime)) \
             else datetime.strptime(started_at, self.DATETIME_FORMAT)
         self.version = version
+        self.ip_addresses = [
+            ipaddr if isinstance(
+                ip_addresses, MarathonIpAddress) else MarathonIpAddress().from_json(ipaddr)
+            for ipaddr in (ip_addresses or [])]
 
+
+class MarathonIpAddress(MarathonObject):
+    """
+    """
+    def __init__(self, ip_address=None, protocol=None):
+        self.ip_address = ip_address
+        self.protocol = protocol
 
 class MarathonHealthCheckResult(MarathonObject):
 


### PR DESCRIPTION
Good day,
this PR fixes #110.

ip_addresses field is passed via __init__ parameters in MarathonTask, but never set.
