### PR TITLE
Add in state to the task model

### DIFF
--- a/marathon/models/task.py
+++ b/marathon/models/task.py
@@ -14,6 +14,7 @@ class MarathonTask(MarathonResource):
     :param str id: task id
     :param list[int] ports: allocated ports
     :param list[int] service_ports: ports exposed for load balancing
+    :param str state: State of the task e.g. TASK_RUNNING
     :param str slave_id: Mesos slave id
     :param staged_at: when this task was staged
     :type staged_at: datetime or str
@@ -26,7 +27,7 @@ class MarathonTask(MarathonResource):
 
     def __init__(
         self, app_id=None, health_check_results=None, host=None, id=None, ports=None, service_ports=None,
-                 slave_id=None, staged_at=None, started_at=None, version=None, ip_addresses=[]):
+                 slave_id=None, staged_at=None, started_at=None, version=None, ip_addresses=[], state=None):
         self.app_id = app_id
         self.health_check_results = health_check_results or []
         self.health_check_results = [
@@ -43,6 +44,7 @@ class MarathonTask(MarathonResource):
             else datetime.strptime(staged_at, self.DATETIME_FORMAT)
         self.started_at = started_at if (started_at is None or isinstance(started_at, datetime)) \
             else datetime.strptime(started_at, self.DATETIME_FORMAT)
+        self.state = state
         self.version = version
         self.ip_addresses = [
             ipaddr if isinstance(


### PR DESCRIPTION
Seems that on Marathon 0.15.5 the task object when performing a `Marathon_Client().get_app` to the `/v2/apps/{app-id}` endpoint has an extra attribute `state` in the response. Simply adding it to the model rectified the issue for me.  

- [x] Add state to the task model
- [x] Test that it addressed the issue
- [x] Ready for review/merge