### PR TITLE
Handle HTTP errors without content graceful

### DIFF
--- a/marathon/exceptions.py
+++ b/marathon/exceptions.py
@@ -8,9 +8,11 @@ class MarathonHttpError(MarathonError):
         """
         :param :class:`requests.Response` response: HTTP response
         """
-        content = response.json()
+        self.error_message = response.reason or ''
+        if response.content:
+            content = response.json()
+            self.error_message = content.get('message', self.error_message)
         self.status_code = response.status_code
-        self.error_message = content.get('message')
         super(MarathonHttpError, self).__init__(self.__str__())
 
     def __repr__(self):

--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -125,7 +125,11 @@ class MarathonApp(MarathonResource):
         self.max_launch_delay_seconds = max_launch_delay_seconds
         self.mem = mem
         self.ports = ports or []
-        self.port_definitions = port_definitions or []
+        self.port_definitions = [
+            pd if isinstance(
+                pd, PortDefinition) else PortDefinition.from_json(pd)
+            for pd in (port_definitions or [])
+        ]
         self.readiness_checks = readiness_checks or []
         self.readiness_check_results = readiness_check_results or []
         self.residency = residency


### PR DESCRIPTION
HTTP errors like 503 do not have a content set by Marathon. Try to use
the response reason string as an alternative error message.