### PR TITLE
Fix py3k regression in 0.8.3

### DIFF
--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -143,7 +143,7 @@ class MarathonApp(MarathonResource):
         self.require_ports = require_ports
 
         self.secrets = secrets or {}
-        for k, s in self.secrets.iteritems():
+        for k, s in self.secrets.items():
             if not isinstance(s, Secret):
                 self.secrets[k] = Secret().from_json(s)
 


### PR DESCRIPTION
.items() works in both.  This dictionary won't ever be especially large,
so the performance hit for not using an iterator in py27 is negligible.

If you really want, I can pull in ```six.iteritems()``` but I didn't see any other uses of ```six``` so I didn't want to introduce a new dependency.