### PR TITLE
Add update_apps method to client

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -13,6 +13,7 @@ import marathon
 from .models import MarathonApp, MarathonDeployment, MarathonGroup, MarathonInfo, MarathonTask, MarathonEndpoint, MarathonQueueItem
 from .exceptions import InternalServerError, NotFoundError, MarathonHttpError, MarathonError
 from .models.events import EventFactory
+from .util import MarathonJsonEncoder, MarathonMinimalJsonEncoder
 
 
 class MarathonClient(object):
@@ -254,6 +255,32 @@ class MarathonClient(object):
 
         response = self._do_request(
             'PUT', '/v2/apps/{app_id}'.format(app_id=app_id), params=params, data=data)
+        return response.json()
+
+    def update_apps(self, apps, force=False, minimal=True):
+        """Update multiple apps.
+
+        Applies writable settings in elements of apps either by upgrading existing ones or creating new ones
+
+        :param apps: sequence of application settings
+        :param bool force: apply even if a deployment is in progress
+        :param bool minimal: ignore nulls and empty collections
+
+        :returns: a dict containing the deployment id and version
+        :rtype: dict
+        """
+        json_repr_apps = []
+        for app in apps:
+            # Changes won't take if version is set - blank it for convenience
+            app.version = None
+            json_repr_apps.append(app.json_repr(minimal=minimal))
+
+        params = {'force': force}
+        encoder = MarathonMinimalJsonEncoder if minimal else MarathonJsonEncoder
+        data = json.dumps(json_repr_apps, cls=encoder, sort_keys=True)
+
+        response = self._do_request(
+            'PUT', '/v2/apps', params=params, data=data)
         return response.json()
 
     def rollback_app(self, app_id, version, force=False):


### PR DESCRIPTION
Currently the python API only supports updating a single app in one call.  The REST API however, support a PUT call to the /v2/apps path that allows for updating several apps in one go.  This PR exposes this call in the form of an update_apps function which takes in a list of MarathonApp objects.  Taking the possible convenience aside for a moment, my actual motivation for this was performance.  We perform update operations on 10s of applications at a time.  Doing these one by one would take up to a few minutes.  Implementing this has trimmed it down to under 10 seconds.  Hopefully the actual implementation is up to common convention for marathon-python, but have no issue changing whatever and submitting a new PR if something is off and it will help to get this merged. 

Thanks, 
Kevin