### PR TITLE
Case for 503 reponse

### DIFF
--- a/marathon/exceptions.py
+++ b/marathon/exceptions.py
@@ -10,8 +10,12 @@ class MarathonHttpError(MarathonError):
         """
         self.error_message = response.reason or ''
         if response.content:
-            content = response.json()
-            self.error_message = content.get('message', self.error_message)
+            try:
+                content = response.json()
+                self.error_message = content.get('message', self.error_message)
+            except ValueError:
+                content = response.content
+                self.error_message = content
         self.status_code = response.status_code
         super(MarathonHttpError, self).__init__(self.__str__())
 


### PR DESCRIPTION
In case, when we got 503, content of response from marathon is not json

```
[ERROR] Got HTTP 503: <html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 503 </title>
</head>
<body>
<h2>HTTP ERROR: 503</h2>
<p>Problem accessing /v2/tasks. Reason:
<pre>    Could not determine the current leader</pre></p>
<hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.z-SNAPSHOT</a><hr/>
</body>
</html>
```
