### PR TITLE
Expose error details from response object MarathonHttpError

### DIFF
--- a/marathon/exceptions.py
+++ b/marathon/exceptions.py
@@ -12,6 +12,7 @@ class MarathonHttpError(MarathonError):
         if response.content:
             content = response.json()
             self.error_message = content.get('message', self.error_message)
+            self.error_details = content.get('details')
         self.status_code = response.status_code
         super(MarathonHttpError, self).__init__(self.__str__())
 


### PR DESCRIPTION
Hello

When attempting to debug a failure on an update of a group of apps, I noticed that the response object was returning a list of error details in addition to a simple message.  These details turned out to be a list of dictionaries, containing detail on each app that was in error, and all errors associated with that app.  It was of the form

```json
[
  {"errors": ["error 1", "error 2"], "path": "/path/to/app1"},
  {"errors": ["error 1", "error 2"], "path": "/path/to/app2"}
]
```

Currently the MarathonHttpError object does not expose the details field from the response object.  This pull request adds the details field to the MarathonHttpError object in addition to the higher level message field from the response that is already a part of the MarathonHttpError object.  I could not find any documentation on the exact contract of the details field.  So this pull request simply keeps them intact as they were in the response, and it is up to the downstream user of the marathon client to parse.  This is a big help, as often the higher level message field only contains something like "Bad Object", where as this contains exact details of each error on each entity you are trying to add/update.