### PR TITLE
Add new Marathon 1.4 API keywords

### DIFF
--- a/marathon/models/group.py
+++ b/marathon/models/group.py
@@ -14,11 +14,13 @@ class MarathonGroup(MarathonResource):
     :param groups:
     :type groups: list[:class:`marathon.models.group.MarathonGroup`] or list[dict]
     :param str id:
+    :param pods:
+    :type pods: list[:class:`marathon.models.pod.MarathonPod`] or list[dict]
     :param str version:
     """
 
     def __init__(self, apps=None, dependencies=None,
-                 groups=None, id=None, version=None):
+                 groups=None, id=None, pods=None, version=None):
         self.apps = [
             a if isinstance(a, MarathonApp) else MarathonApp().from_json(a)
             for a in (apps or [])
@@ -28,5 +30,11 @@ class MarathonGroup(MarathonResource):
             g if isinstance(g, MarathonGroup) else MarathonGroup().from_json(g)
             for g in (groups or [])
         ]
+        self.pods = []
+        # ToDo: Create class MarathonPod
+        # self.pods = [
+        #     p if isinstance(p, MarathonPod) else MarathonPod().from_json(p)
+        #     for p in (pods or [])
+        # ]
         self.id = assert_valid_id(id)
         self.version = version

--- a/marathon/models/task.py
+++ b/marathon/models/task.py
@@ -73,12 +73,14 @@ class MarathonHealthCheckResult(MarathonObject):
     :param str last_failure_cause: cause for last failure
     :param str last_success: last time when which healthcheck succeeded
     :param str task_id: task id
+    :param str instance_id: instance id
     """
 
     DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
     def __init__(self, alive=None, consecutive_failures=None, first_success=None,
-                 last_failure=None, last_success=None, task_id=None, last_failure_cause=None):
+                 last_failure=None, last_success=None, task_id=None,
+                 last_failure_cause=None, instance_id=None):
         self.alive = alive
         self.consecutive_failures = consecutive_failures
         self.first_success = first_success if (first_success is None or isinstance(first_success, datetime)) \
@@ -89,3 +91,4 @@ class MarathonHealthCheckResult(MarathonObject):
             else datetime.strptime(last_success, self.DATETIME_FORMAT)
         self.task_id = task_id
         self.last_failure_cause = last_failure_cause
+        self.instance_id = instance_id


### PR DESCRIPTION
Looks like we did the same thing to some extend.
I also identified the new `MarathonGroup.pods` and `MarathonHealthCheckResult.instance_id`.
Have not had the need to implement the proper `pod` classes, that's why I put in a ToDo note.