### PR TITLE
Adds MarathonApp.add_env() method

### DIFF
--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -119,7 +119,7 @@ class MarathonApp(MarathonResource):
             for d in (deployments or [])
         ]
         self.disk = disk
-        self.env = env
+        self.env = env or dict()
         self.executor = executor
         self.gpus = gpus
         self.health_checks = health_checks or []
@@ -184,6 +184,9 @@ class MarathonApp(MarathonResource):
             else MarathonAppVersionInfo.from_json(version_info)
         self.task_stats = task_stats if (isinstance(task_stats, MarathonTaskStats) or task_stats is None) \
             else MarathonTaskStats.from_json(task_stats)
+
+    def add_env(self, key, value):
+        self.env[key] = value
 
 
 class MarathonHealthCheck(MarathonObject):

--- a/tests/test_model_app.py
+++ b/tests/test_model_app.py
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+from marathon.models.app import MarathonApp
+import unittest
+
+
+class MarathonAppTest(unittest.TestCase):
+
+    def test_env_defaults_to_empty_dict(self):
+        """
+        é testé
+        """
+        app = MarathonApp()
+        self.assertEquals(app.env, {})
+
+    def test_add_env_empty_dict(self):
+        app = MarathonApp()
+        app.add_env("MY_ENV", "my-value")
+        self.assertDictEqual({"MY_ENV": "my-value"}, app.env)
+
+    def test_add_env_non_empty_dict(self):
+        env_data = {"OTHER_ENV": "other-value"}
+        app = MarathonApp(env=env_data)
+
+        app.add_env("MY_ENV", "my-value")
+        self.assertDictEqual({"MY_ENV": "my-value", "OTHER_ENV": "other-value"}, app.env)


### PR DESCRIPTION
Hello,

This PR adds a convenient method to manipulate the dict of env vars of an App model. Hope it helps.

I'm currently building an HTTP API that sits in front of Marathon and I'm currently using your project to wrap all calls to Marathon HTTP API.