### PR TITLE
Fix json decoder

### DIFF
--- a/marathon/exceptions.py
+++ b/marathon/exceptions.py
@@ -1,3 +1,6 @@
+from simplejson.scanner import JSONDecodeError
+
+
 class MarathonError(Exception):
     pass
 
@@ -10,9 +13,12 @@ class MarathonHttpError(MarathonError):
         """
         self.error_message = response.reason or ''
         if response.content:
-            content = response.json()
-            self.error_message = content.get('message', self.error_message)
-            self.error_details = content.get('details')
+            try:
+                content = response.json()
+                self.error_message = content.get('message', self.error_message)
+                self.error_details = content.get('details')
+            except JSONDecodeError:
+                pass
         self.status_code = response.status_code
         super(MarathonHttpError, self).__init__(self.__str__())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.11.1
+simplejson

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import mock
+from marathon.exceptions import MarathonHttpError
+from simplejson.scanner import JSONDecodeError
+
+
+def test_marathon_http_error():
+    mock_response = mock.Mock(reason='thing',
+                              content=None,
+                              status_code=404)
+    ret = MarathonHttpError(mock_response)
+    assert ret.status_code == 404
+    assert ret.error_message == 'thing'
+
+
+def test_marathon_http_error_content():
+    mock_json = mock.Mock(return_value={'message': 'oh no',
+                                        'details': 'something_bad'})
+    mock_response = mock.Mock(reason='thing',
+                              content=True,
+                              status_code=404,
+                              json=mock_json)
+    ret = MarathonHttpError(mock_response)
+    assert ret.error_message == 'oh no'
+    assert ret.error_details == 'something_bad'
+
+    mock_json = mock.Mock(side_effect=JSONDecodeError('BOOM', 'aaa', 2))
+    mock_response = mock.Mock(reason='thing',
+                              content=True,
+                              status_code=404,
+                              json=mock_json)
+    ret = MarathonHttpError(mock_response)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ changedir =
   test: {toxinidir}
   itest: {toxinidir}/itests/
 deps =
+    --editable={toxinidir}
     -rrequirements.txt
     requests-mock==1.0.0
     docker-compose


### PR DESCRIPTION
Currently if Marathon returns a 503 because it can't find a leader the
client blows up trying to handle the exception because the response is
not JSON. This catches that case so that the original exception is
thrown rather than JSONDecodeError.