### PR TITLE
Update to work with Marathon 1.4.0

### DIFF
--- a/itests/install-marathon.sh
+++ b/itests/install-marathon.sh
@@ -20,7 +20,7 @@ sudo apt-get -y purge oracle-java7-installer
 sudo update-java-alternatives -s java-8-oracle
 sudo DEBIAN_FRONTEND=noninteractive apt-get install oracle-java8-set-default
 
-sudo DEBIAN_FRONTEND=noninteractive apt-get -y --force-yes install mesos=1.0.* marathon=$MARATHONVERSION*
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y --force-yes install mesos=1.1.* marathon=$MARATHONVERSION*
 
 # WTF MARATHON?
 # Why does the precise version have java7 hardcoded if it requires java8?

--- a/itests/install-marathon.sh
+++ b/itests/install-marathon.sh
@@ -12,9 +12,7 @@ CODENAME=$(lsb_release -cs)
 
 # Add the repository
 echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" | sudo tee /etc/apt/sources.list.d/mesosphere.list
-# Temporary repo to get marathon 1.4
-echo "deb https://dl.bintray.com/yelp/paasta trusty main" | sudo tee /etc/apt/sources.list.d/paasta.list
-sudo apt-get -y install apt-transport-https && sudo apt-get update
+sudo apt-get update
 
 # Install packages
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y install oracle-java8-installer

--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -84,7 +84,7 @@ class MarathonApp(MarathonResource):
         'deployments', 'tasks', 'tasks_running', 'tasks_staged', 'tasks_healthy', 'tasks_unhealthy']
     """List of read-only attributes"""
 
-    KILL_SELECTIONS = ["YoungestFirst", "OldestFirst"]
+    KILL_SELECTIONS = ["YOUNGEST_FIRST", "OLDEST_FIRST"]
 
     def __init__(self, accepted_resource_roles=None, args=None, backoff_factor=None, backoff_seconds=None, cmd=None,
                  constraints=None, container=None, cpus=None, dependencies=None, deployments=None, disk=None, env=None,


### PR DESCRIPTION
Marathon 1.4.0 updated the `KILL_SELECTIONS`: https://github.com/mesosphere/marathon/issues/4882 . We also no longer need the yelp/paasta apt repository.