### PR TITLE
fixes: local variable 'response' referenced before assignment

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -119,11 +119,12 @@ class MarathonClient(object):
                     headers={'Accept': 'text/event-stream'},
                     auth=self.auth
                 )
+                if response.ok:
+                    return response.iter_lines()
+                response.raise_for_status()
             except Exception as e:
                 marathon.log.error('Error while calling %s: %s', url, e.message)
 
-            if response.ok:
-                return response.iter_lines()
 
         raise MarathonError('No remaining Marathon servers to try')
 


### PR DESCRIPTION
`response` won't be initialized in case an exception was thrown, causing the following error:

```
  File "/usr/local/lib/python2.7/site-packages/marathon/client.py", line 125, in _do_sse_request
    if response.ok:
UnboundLocalError: local variable 'response' referenced before assignment
```