### PR TITLE
Updated event.py to handle app_terminated_event.

### DIFF
--- a/marathon/models/events.py
+++ b/marathon/models/events.py
@@ -114,6 +114,8 @@ class MarathonEventStreamDetached(MarathonEvent):
 class MarathonUnhealthyTaskKillEvent(MarathonEvent):
     KNOWN_ATTRIBUTES = ['app_id', 'task_id', 'version', 'reason']
 
+class MarathonAppTerminatedEvent(MarathonEvent):
+    KNOWN_ATTRIBUTES = ['app_id']
 
 class EventFactory:
 
@@ -145,6 +147,7 @@ class EventFactory:
         'deployment_step_failure': MarathonDeploymentStepFailure,
         'event_stream_attached': MarathonEventStreamAttached,
         'event_stream_detached': MarathonEventStreamDetached,
+        'app_terminated_event': MarathonAppTerminatedEvent,
     }
 
     def process(self, event):

--- a/marathon/models/events.py
+++ b/marathon/models/events.py
@@ -114,8 +114,10 @@ class MarathonEventStreamDetached(MarathonEvent):
 class MarathonUnhealthyTaskKillEvent(MarathonEvent):
     KNOWN_ATTRIBUTES = ['app_id', 'task_id', 'version', 'reason']
 
+
 class MarathonAppTerminatedEvent(MarathonEvent):
     KNOWN_ATTRIBUTES = ['app_id']
+
 
 class EventFactory:
 


### PR DESCRIPTION
As of now, when the event stream gets a  app_terminated_event, it raises an exeption : 
MarathonError: Unknown event_type: app_terminated_event, data: {u'eventType': u'app_terminated_event', u'timestamp': u'2017-02-23T08:54:44.470Z', u'appId': u'/longtest/ms/beds-node'}
This fixs it.

Closes #151.