### PR TITLE
Use Marathon /v2/apps/<app_id>/tasks endpoint to get tasks by id.

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -477,13 +477,10 @@ class MarathonClient(object):
         :returns: list of tasks
         :rtype: list[:class:`marathon.models.task.MarathonTask`]
         """
-        response = self._do_request('GET', '/v2/tasks')
+        response = self._do_request(
+            'GET', '/v2/apps/%s/tasks' % app_id if app_id else '/v2/tasks')
         tasks = self._parse_response(
             response, MarathonTask, is_list=True, resource_name='tasks')
-        if app_id:
-            tasks = [
-                task for task in tasks if task.app_id.lstrip('/') == app_id.lstrip('/')]
-
         [setattr(t, 'app_id', app_id)
          for t in tasks if app_id and t.app_id is None]
         for k, v in kwargs.items():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -120,14 +120,9 @@ def test_list_tasks_with_app_id():
                     '"lastFailure": null, "lastSuccess": "2014-10-03T22:57:41.643Z", "taskId": "bridged-webapp.eb76c51f-4b4a-11e4-ae49-56847afe9799" } ],' \
                     ' "host": "10.141.141.10", "id": "bridged-webapp.eb76c51f-4b4a-11e4-ae49-56847afe9799", "ports": [ 31000 ], ' \
                     '"servicePorts": [ 9000 ], "stagedAt": "2014-10-03T22:16:27.811Z", "startedAt": "2014-10-03T22:57:41.587Z", ' \
-                    '"version": "2014-10-03T22:16:23.634Z" }, { "appId": "/anotherapp", ' \
-                    '"healthCheckResults": [ { "alive": true, "consecutiveFailures": 0, "firstSuccess": "2014-10-03T22:57:02.246Z", "lastFailure": null, ' \
-                    '"lastSuccess": "2014-10-03T22:57:41.649Z", "taskId": "bridged-webapp.ef0b5d91-4b4a-11e4-ae49-56847afe9799" } ], ' \
-                    '"host": "10.141.141.10", "id": "bridged-webapp.ef0b5d91-4b4a-11e4-ae49-56847afe9799", "ports": [ 31001 ], ' \
-                    '"servicePorts": [ 9000 ], "stagedAt": "2014-10-03T22:16:33.814Z", "startedAt": "2014-10-03T22:57:41.593Z", ' \
-                    '"version": "2014-10-03T22:16:23.634Z" } ] }'
+                    '"version": "2014-10-03T22:16:23.634Z" }]}'
     with requests_mock.mock() as m:
-        m.get('http://fake_server/v2/tasks', text=fake_response)
+        m.get('http://fake_server/v2/apps//anapp/tasks', text=fake_response)
         mock_client = MarathonClient(servers='http://fake_server')
         actual_deployments = mock_client.list_tasks(app_id='/anapp')
         expected_deployments = [models.task.MarathonTask(


### PR DESCRIPTION
In Marathon 1.4.1 `/v2/tasks` endpoint returns empty list, however there is `/v2/apps/<app_id>/tasks` endpoint which seems to be better for this case anyway.