### PR TITLE
[fix] Handle non-JSON errors from Marathon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,10 @@ script:
 # Work around travis-ci/travis-ci#5227
 addons:
   hostname: localhost
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - libstdc++6-4.7-dev
+
+sudo: required # make it explicit: it was by default only because this repo was set up before 2015 (new forks need it)

--- a/marathon/exceptions.py
+++ b/marathon/exceptions.py
@@ -9,7 +9,7 @@ class MarathonHttpError(MarathonError):
         :param :class:`requests.Response` response: HTTP response
         """
         self.error_message = response.reason or ''
-        if response.content:
+        if response.content and 'application/json' in response.headers.get('content-type', ''):
             content = response.json()
             self.error_message = content.get('message', self.error_message)
             self.error_details = content.get('details')

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,38 @@
+import json
+
+import requests
+
+from marathon.exceptions import MarathonHttpError, InternalServerError
+
+
+def test_400_error():
+    fake_response = requests.Response()
+    fake_message = "Invalid JSON"
+    fake_details = [{"path": "/taskKillGracePeriodSeconds", "errors": ["error.expected.jsnumber"]}]
+    fake_response._content = json.dumps({"message": fake_message, "details": fake_details}).encode()
+    fake_response.status_code = 400
+    fake_response.headers['Content-Type'] = 'application/json'
+
+    exc = MarathonHttpError(fake_response)
+    assert exc.status_code == 400
+    assert exc.error_message == fake_message
+    assert exc.error_details == fake_details
+
+
+def test_503_error():
+    fake_response = requests.Response()
+    fake_response._content = """<head>
+<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
+<title>Error 503 </title>
+</head>
+<body>
+<h2>HTTP ERROR: 503</h2>
+</body>
+</html>"""
+    fake_response.reason = "reason"
+    fake_response.status_code = 503
+
+    exc = InternalServerError(fake_response)
+    assert exc.status_code == 503
+    assert exc.error_message == "reason"
+    assert not hasattr(exc, 'error_details')


### PR DESCRIPTION
- it answers to https://github.com/thefactory/marathon-python/issues/22
- it proposes a different implementation (without catching exceptions) than:
  - https://github.com/thefactory/marathon-python/pull/167/commits/9443c7d188b033ad0d5fc01001c9c4e48e658dac
  - https://github.com/thefactory/marathon-python/pull/138/commits/7f2999f7c052a196eb74754f997798d899a0c486
- it adds two tests to verify the behavior of the new condition