### PR TITLE
[fix] broken build: glibc++ not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,10 @@ script:
 # Work around travis-ci/travis-ci#5227
 addons:
   hostname: localhost
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - libstdc++6-4.7-dev
+
+sudo: required # make it explicit: it was by default only because this repo was set up before 2015 (new forks need it)


### PR DESCRIPTION
Fix broken build (see https://github.com/thefactory/marathon-python/issues/180)