### PR TITLE
Remove out of date constraint validation of operator.

### DIFF
--- a/marathon/models/constraint.py
+++ b/marathon/models/constraint.py
@@ -16,12 +16,9 @@ class MarathonConstraint(MarathonObject):
     :type value: str, int, or None
     """
 
-    OPERATORS = ['UNIQUE', 'CLUSTER', 'GROUP_BY', 'LIKE', 'UNLIKE']
     """Valid operators"""
 
     def __init__(self, field, operator, value=None):
-        if operator not in self.OPERATORS:
-            raise InvalidChoiceError('operator', operator, self.OPERATORS)
         self.field = field
         self.operator = operator
         self.value = value


### PR DESCRIPTION
`MAX_PER` is missing. More will be in the future, I'm sure.

> The client should not enforce what the API accepts as parameter options at the very least.

Ty.