### PR TITLE
Add requests session param tip.

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -32,6 +32,7 @@ class MarathonClient(object):
         :type servers: str or list[str]
         :param str username: Basic auth username
         :param str password: Basic auth password
+        :param requests.session session: requests.session for reusing the connections
         :param int timeout: Timeout (in seconds) for requests to Marathon
         :param str auth_token: Token-based auth token, used with DCOS + Oauth
         :param bool verify: Enable SSL certificate verification


### PR DESCRIPTION
Hi folks,

I'd suggest adding the param note in the `MarathonClient` initial method as I have been stricken by the `requests.session reusing` issue.

In my environment, my web server calls a lot of times to marathon via `marathon-python`, and I initial the client each call, so it appears thousands of TIME_WAIT connections on the server. Thus, adding the session param hint will help the others clear about that.

Thanks.