### PR TITLE
Fix MarathonResource hash as well

### DIFF
--- a/marathon/models/base.py
+++ b/marathon/models/base.py
@@ -71,6 +71,12 @@ class MarathonResource(MarathonObject):
         except:
             return False
 
+    def __hash__(self):
+        # Technically this class shouldn't be hashable because it often
+        # contains mutable fields, but in practice this class is used more
+        # like a record or namedtuple.
+        return hash(self.to_json())
+
     def __str__(self):
         return "{clazz}::".format(clazz=self.__class__.__name__) + str(self.__dict__)
 

--- a/tests/test_model_object.py
+++ b/tests/test_model_object.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from marathon.models.base import MarathonObject
+from marathon.models.base import MarathonResource
 import unittest
 
 
@@ -16,6 +17,24 @@ class MarathonObjectTest(unittest.TestCase):
         This test ensures that we are hashable in all versions of python
         """
         obj = MarathonObject()
+        collection = {}
+        collection[obj] = True
+        assert collection[obj]
+
+
+class MarathonResourceHashable(unittest.TestCase):
+
+    def test_hashable(self):
+        """
+        Regression test for issue #203
+
+        MarathonResource defined __eq__ but not __hash__, meaning that in
+        in Python2.7 MarathonResources are hashable, but in Python3 they're
+        not
+
+        This test ensures that we are hashable in all versions of python
+        """
+        obj = MarathonResource()
         collection = {}
         collection[obj] = True
         assert collection[obj]


### PR DESCRIPTION
Turns out that Python3 does not allow child classes to inherit __hash__ methods, if you explicitly define __eq__ you also have to explicitly define __eq__.

MarathonTask -> MarathonResource -> MarathonObject, so for MarathonTasks to be hashible we actually need to define __hash__ on MarathonResource.

Oops.