### PR TITLE
Add "udp,tcp" to authorized protocols for containers

### DIFF
--- a/marathon/models/container.py
+++ b/marathon/models/container.py
@@ -83,7 +83,7 @@ class MarathonContainerPortMapping(MarathonObject):
     :param object labels:
     """
 
-    PROTOCOLS = ['tcp', 'udp']
+    PROTOCOLS = ['tcp', 'udp', 'udp,tcp']
     """Valid protocols"""
 
     def __init__(self, name=None, container_port=None, host_port=0, service_port=None, protocol='tcp', labels=None):


### PR DESCRIPTION
Hi !

I just added the 'udp,tcp' protocol to the container ones, it is now supported by Marathon. Don't hesitate to ask more !

Fixes #150.