### PR TITLE
Support filtering applications by labels

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -131,7 +131,8 @@ class MarathonClient(object):
                     auth=self.auth
                 )
             except Exception as e:
-                marathon.log.error('Error while calling %s: %s', url, e.message)
+                marathon.log.error(
+                    'Error while calling %s: %s', url, e.message)
             else:
                 if response.ok:
                     return response.iter_lines()
@@ -450,7 +451,8 @@ class MarathonClient(object):
         params = {'force': force}
         response = self._do_request(
             'PUT',
-            '/v2/groups/{group_id}/versions/{version}'.format(group_id=group_id, version=version),
+            '/v2/groups/{group_id}/versions/{version}'.format(
+                group_id=group_id, version=version),
             params=params)
         return response.json()
 
@@ -764,7 +766,8 @@ class MarathonClient(object):
 
         params = {
             'event_type': [
-                EventFactory.class_to_event[et] if isinstance(et, type) and issubclass(et, MarathonEvent) else et
+                EventFactory.class_to_event[et] if isinstance(
+                    et, type) and issubclass(et, MarathonEvent) else et
                 for et in event_types or []
             ]
         }

--- a/marathon/client.py
+++ b/marathon/client.py
@@ -166,7 +166,7 @@ class MarathonClient(object):
     def list_apps(self, cmd=None, embed_tasks=False, embed_counts=False,
                   embed_deployments=False, embed_readiness=False,
                   embed_last_task_failure=False, embed_failures=False,
-                  embed_task_stats=False, app_id=None, **kwargs):
+                  embed_task_stats=False, app_id=None, label=None, **kwargs):
         """List all apps.
 
         :param str cmd: if passed, only show apps with a matching `cmd`
@@ -178,6 +178,7 @@ class MarathonClient(object):
         :param bool embed_failures: shorthand for embed_last_task_failure
         :param bool embed_task_stats: embed task stats in result
         :param str app_id: if passed, only show apps with an 'id' that matches or contains this value
+        :param str label: if passed, only show apps with the selected labels
         :param kwargs: arbitrary search filters
 
         :returns: list of applications
@@ -188,6 +189,8 @@ class MarathonClient(object):
             params['cmd'] = cmd
         if app_id:
             params['id'] = app_id
+        if label:
+            params['label'] = label
 
         embed_params = {
             'app.tasks': embed_tasks,


### PR DESCRIPTION
This is the API in marathon: `GET /v2/apps?label={labelSelectorQuery}`

Applications needs to format their queries into `str` since it's difficult to compose the query string from `marathon-python` point of view. 

Thanks for reviewing. 