### PR TITLE
Remove default container.docker.network

### DIFF
--- a/marathon/models/container.py
+++ b/marathon/models/container.py
@@ -63,7 +63,7 @@ class MarathonDockerContainer(MarathonObject):
     NETWORK_MODES = ['BRIDGE', 'HOST', 'USER', 'NONE']
     """Valid network modes"""
 
-    def __init__(self, image=None, network='HOST', port_mappings=None, parameters=None, privileged=None,
+    def __init__(self, image=None, network=None, port_mappings=None, parameters=None, privileged=None,
                  force_pull_image=None, **kwargs):
         self.image = image
         if network:


### PR DESCRIPTION
Remove container.docker.network default value to allow using MESOS container engine and .networks on newer versions of marathon

See issue #186 