### PR TITLE
Removes id validation from MarathonGroup()

### DIFF
--- a/marathon/models/base.py
+++ b/marathon/models/base.py
@@ -13,7 +13,7 @@ class MarathonObject(object):
     def __eq__(self, other):
         try:
             return self.__dict__ == other.__dict__
-        except:
+        except Exception:
             return False
 
     def __hash__(self):
@@ -68,7 +68,7 @@ class MarathonResource(MarathonObject):
     def __eq__(self, other):
         try:
             return self.__dict__ == other.__dict__
-        except:
+        except Exception:
             return False
 
     def __hash__(self):

--- a/marathon/models/group.py
+++ b/marathon/models/group.py
@@ -36,5 +36,5 @@ class MarathonGroup(MarathonResource):
         #     p if isinstance(p, MarathonPod) else MarathonPod().from_json(p)
         #     for p in (pods or [])
         # ]
-        self.id = assert_valid_id(id)
+        self.id = id
         self.version = version

--- a/marathon/models/group.py
+++ b/marathon/models/group.py
@@ -1,4 +1,4 @@
-from .base import MarathonResource, assert_valid_id
+from .base import MarathonResource
 from .app import MarathonApp
 
 

--- a/tests/test_model_group.py
+++ b/tests/test_model_group.py
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+from marathon.models.group import MarathonGroup
+import unittest
+
+
+class MarathonGroupTest(unittest.TestCase):
+
+    def test_from_json_parses_root_group(self):
+       data = {
+               "id": "/",
+               "groups": [
+                   {"id": "/foo", "apps": []},
+                   {"id": "/bla", "apps": []},
+               ],
+               "apps": []
+           }
+       group = MarathonGroup().from_json(data)
+       self.assertEqual("/", group.id)
+

--- a/tests/test_model_group.py
+++ b/tests/test_model_group.py
@@ -7,14 +7,13 @@ import unittest
 class MarathonGroupTest(unittest.TestCase):
 
     def test_from_json_parses_root_group(self):
-       data = {
-               "id": "/",
-               "groups": [
-                   {"id": "/foo", "apps": []},
-                   {"id": "/bla", "apps": []},
-               ],
-               "apps": []
-           }
-       group = MarathonGroup().from_json(data)
-       self.assertEqual("/", group.id)
-
+        data = {
+                   "id": "/",
+                   "groups": [
+                       {"id": "/foo", "apps": []},
+                       {"id": "/bla", "apps": []},
+                   ],
+                   "apps": []
+        }
+        group = MarathonGroup().from_json(data)
+        self.assertEqual("/", group.id)


### PR DESCRIPTION
This validation was preventig the use of the root group (`/`), both from
`MarathonGroup().from_json(<data>)` and `MarathonClient().get_group("/")`

Fixes issue #227