### PR TITLE
Fix health check 'command' 

### DIFF
--- a/marathon/__init__.py
+++ b/marathon/__init__.py
@@ -1,7 +1,6 @@
-import logging
-
 from .client import MarathonClient
 from .models import MarathonResource, MarathonApp, MarathonTask, MarathonConstraint
 from .exceptions import MarathonError, MarathonHttpError, NotFoundError, InvalidChoiceError
+from .util import get_log
 
-log = logging.getLogger(__name__)
+log = get_log()

--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -214,7 +214,9 @@ class MarathonHealthCheck(MarathonObject):
     def __init__(self, command=None, grace_period_seconds=None, interval_seconds=None, max_consecutive_failures=None,
                  path=None, port_index=None, protocol=None, timeout_seconds=None, ignore_http1xx=None, **kwargs):
 
-        if is_stringy(command):
+        if command is None:
+            self.command = None
+        elif is_stringy(command):
             self.command = {
                 "value": command
             }

--- a/marathon/models/app.py
+++ b/marathon/models/app.py
@@ -6,6 +6,9 @@ from .constraint import MarathonConstraint
 from .container import MarathonContainer
 from .deployment import MarathonDeployment
 from .task import MarathonTask
+from ..util import is_stringy, get_log
+
+log = get_log()
 
 
 class MarathonApp(MarathonResource):
@@ -210,7 +213,19 @@ class MarathonHealthCheck(MarathonObject):
 
     def __init__(self, command=None, grace_period_seconds=None, interval_seconds=None, max_consecutive_failures=None,
                  path=None, port_index=None, protocol=None, timeout_seconds=None, ignore_http1xx=None, **kwargs):
-        self.command = command
+
+        if is_stringy(command):
+            self.command = {
+                "value": command
+            }
+        elif type(command) is dict and 'value' in command:
+            log.warn('Deprecated: Using command as dict instead of string is deprecated')
+            self.command = {
+                "value": command['value']
+            }
+        else:
+            raise ValueError('Invalid command format: {}'.format(command))
+
         self.grace_period_seconds = grace_period_seconds
         self.interval_seconds = interval_seconds
         self.max_consecutive_failures = max_consecutive_failures
@@ -318,8 +333,8 @@ class MarathonAppVersionInfo(MarathonObject):
     """
 
     DATETIME_FORMATS = [
-      '%Y-%m-%dT%H:%M:%S.%fZ',
-      '%Y-%m-%dT%H:%M:%SZ',
+        '%Y-%m-%dT%H:%M:%S.%fZ',
+        '%Y-%m-%dT%H:%M:%SZ',
     ]
 
     def __init__(self, last_scaling_at=None, last_config_change_at=None):

--- a/marathon/util.py
+++ b/marathon/util.py
@@ -1,5 +1,6 @@
 import collections
 import datetime
+import logging
 
 try:
     import json
@@ -8,6 +9,10 @@ except ImportError:
 import re
 
 from ._compat import string_types
+
+
+def get_log():
+    return logging.getLogger(__name__.split('.')[0])
 
 
 def is_stringy(obj):


### PR DESCRIPTION
#222

The current version of marathon-python (0.9.2) generates COMMAND type protocol healthchecks command property as a string, but current version of marathon expects an object with the 'value' property:

Current:
```json
{
  "protocol": "COMMAND",
  "command":  "curl -f -X GET http://$HOST:$PORT0/health"
}
```
Expected:
```json
{
  "protocol": "COMMAND",
  "command": { "value": "curl -f -X GET http://$HOST:$PORT0/health" }
}
```

I can see that all the messages in the package are handled by the logger defined in the `marathon/__init__.py`, so instead of using the `warnings` package to issue a `DeprecationWarning` I would rather user `marathon.log.warn()` to be in accordance with the rest of the package.

I don't wanna do  a `import  marathon` because I'd be importing many things I don't need into `app.py`, but yet it's consistent to make all places that uses the log imports it from the same place.

So my solution was:

Remove `import logging` and `log = logging.getLogger(__name__)` from `marathon/__init__.py` and replace by a call to a function in `marathon/util.py` called *get_log* to retrieve the log, so it can be sued anywhere with importing unnecessary thins from `marathon/__init__.py`. 