### PR TITLE
Possibility for send the full json object on create

### DIFF
--- a/marathon/client.py
+++ b/marathon/client.py
@@ -148,17 +148,18 @@ class MarathonClient(object):
         """
         return MarathonEndpoint.from_tasks(self.list_tasks())
 
-    def create_app(self, app_id, app):
+    def create_app(self, app_id, app, minimal=True):
         """Create and start an app.
 
         :param str app_id: application ID
         :param :class:`marathon.models.app.MarathonApp` app: the application to create
+        :param bool minimal: ignore nulls and empty collections
 
         :returns: the created app (on success)
         :rtype: :class:`marathon.models.app.MarathonApp` or False
         """
         app.id = app_id
-        data = app.to_json()
+        data = app.to_json(minimal=minimal)
         response = self._do_request('POST', '/v2/apps', data=data)
         if response.status_code == 201:
             return self._parse_response(response, MarathonApp)


### PR DESCRIPTION
Some of our marathon applications requires an empty port configuration on create. We do it by setting the `portsMapping` to `null`, but that value is ignored by `create_app` because we don't have control on `minimal` parameter when serializing app configuration.