### PR TITLE
Added region and zone members to task model.

### DIFF
--- a/marathon/models/task.py
+++ b/marathon/models/task.py
@@ -21,12 +21,17 @@ class MarathonTask(MarathonResource):
     :param started_at: when this task was started
     :type started_at: datetime or str
     :param str version: app version with which this task was started
+    :type region: str
+    :param region: fault domain region support in DCOS EE
+    :type zone: str
+    :param zone: fault domain zone support in DCOS EE
     """
 
     DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
     def __init__(self, app_id=None, health_check_results=None, host=None, id=None, ports=None, service_ports=None,
-                 slave_id=None, staged_at=None, started_at=None, version=None, ip_addresses=[], state=None, local_volumes=None):
+                 slave_id=None, staged_at=None, started_at=None, version=None, ip_addresses=[], state=None, local_volumes=None,
+                 region=None, zone=None):
         self.app_id = app_id
         self.health_check_results = health_check_results or []
         self.health_check_results = [
@@ -50,6 +55,8 @@ class MarathonTask(MarathonResource):
                 ip_addresses, MarathonIpAddress) else MarathonIpAddress().from_json(ipaddr)
             for ipaddr in (ip_addresses or [])]
         self.local_volumes = local_volumes or []
+        self.region = region
+        self.zone = zone
 
 
 class MarathonIpAddress(MarathonObject):


### PR DESCRIPTION
Missing region and zone members resulted in stack trace when making calls
to `client.get_app` under DCOS EE 1.11+. I've resolved the problem with addition of both kwargs to `MarathonTask`. It was unclear to me how I could adequately test this with the behave tests. The main problem I had was in identifying how to enable the Marathon region and zone values in the open-source releases. I'm happy to provide test coverage if you can provide a pointer to how I'd accomplish this. Regardless, I've tested to ensure this resolves my individual problem.

Stack trace snippet experienced when using `marathon` package against DCOS EE 1.11.8 cluster deployed in AWS:
```
  File "/usr/lib/python2.7/site-packages/marathon/client.py", line 252, in get_app
    return self._parse_response(response, MarathonApp, resource_name='app')
  File "/usr/lib/python2.7/site-packages/marathon/client.py", line 74, in _parse_response
    return clazz.from_json(target)
  File "/usr/lib/python2.7/site-packages/marathon/models/base.py", line 43, in from_json
    return cls(**{to_snake_case(k): v for k, v in attributes.items()})
  File "/usr/lib/python2.7/site-packages/marathon/models/app.py", line 169, in __init__
    for t in (tasks or [])
  File "/usr/lib/python2.7/site-packages/marathon/models/base.py", line 43, in from_json
    return cls(**{to_snake_case(k): v for k, v in attributes.items()})
TypeError: __init__() got an unexpected keyword argument 'zone'
```

This is the response from the /v2/apps/scale-elasticsearch/ Marathon API for reference:
```
{
  "app": {
    "id": "/scale-elasticsearch",
    "backoffFactor": 1.15,
    "backoffSeconds": 1,
    "container": {
      "type": "DOCKER",
      "docker": {
        "forcePullImage": false,
        "image": "elasticsearch:2-alpine",
        "parameters": [],
        "privileged": false
      },
      "volumes": [],
      "portMappings": [
        {
          "containerPort": 9200,
          "hostPort": 0,
          "labels": {
            "VIP_0": "/scale-elasticsearch:9200"
          },
          "protocol": "tcp",
          "servicePort": 10104
        }
      ]
    },
    "cpus": 1,
    "disk": 0,
    "executor": "",
    "healthChecks": [
      {
        "gracePeriodSeconds": 300,
        "intervalSeconds": 60,
        "maxConsecutiveFailures": 3,
        "portIndex": 0,
        "protocol": "MESOS_HTTP",
        "ipProtocol": "IPv4",
        "timeoutSeconds": 20,
        "delaySeconds": 15
      }
    ],
    "instances": 1,
    "labels": {},
    "maxLaunchDelaySeconds": 3600,
    "mem": 512,
    "gpus": 0,
    "networks": [
      {
        "mode": "container/bridge"
      }
    ],
    "requirePorts": false,
    "upgradeStrategy": {
      "maximumOverCapacity": 1,
      "minimumHealthCapacity": 1
    },
    "version": "2018-12-27T17:42:53.175Z",
    "versionInfo": {
      "lastScalingAt": "2018-12-27T17:42:53.175Z",
      "lastConfigChangeAt": "2018-12-27T17:42:53.175Z"
    },
    "killSelection": "YOUNGEST_FIRST",
    "unreachableStrategy": {
      "inactiveAfterSeconds": 0,
      "expungeAfterSeconds": 0
    },
    "tasksStaged": 0,
    "tasksRunning": 1,
    "tasksHealthy": 1,
    "tasksUnhealthy": 0,
    "deployments": [],
    "tasks": [
      {
        "appId": "/scale-elasticsearch",
        "healthCheckResults": [
          {
            "alive": true,
            "consecutiveFailures": 0,
            "firstSuccess": "2018-12-27T17:43:14.876Z",
            "instanceId": "instance [scale-elasticsearch.marathon-d69e9176-09fe-11e9-964b-8e27d858ac7e]",
            "lastSuccess": "2018-12-27T17:43:14.876Z"
          }
        ],
        "host": "172.12.24.142",
        "id": "scale-elasticsearch.d69e9176-09fe-11e9-964b-8e27d858ac7e",
        "ipAddresses": [
          {
            "ipAddress": "172.17.0.2",
            "protocol": "IPv4"
          }
        ],
        "ports": [
          20227
        ],
        "servicePorts": [],
        "slaveId": "21f0ff64-120b-4f94-b0fb-0f886030395a-S0",
        "state": "TASK_RUNNING",
        "stagedAt": "2018-12-27T17:42:53.934Z",
        "startedAt": "2018-12-27T17:42:59.720Z",
        "version": "2018-12-27T17:42:53.175Z",
        "localVolumes": [],
        "region": "us-east-1",
        "zone": "us-east-1b"
      }
    ]
  }
}
```