### PR TITLE
Moving marathon away from ubuntu and starting from mesosphere dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,12 @@ services:
 python:
   - 3.6
   - 3.7
-include:
-  - python: 3.7
-    env: TOX_ENV=py37
-  - python: 3.6
-    env: TOX_ENV=py36
+jobs:
+  include:
+    - python: 3.7
+      env: TOX_ENV=py37
+    - python: 3.6
+      env: TOX_ENV=py36
 before_install:
   - docker pull "missingcharacter/marathon-python:${MARATHONVERSION}"
   - docker run --name marathon-python -d -p 8080:8080 -p 5050:5050 "missingcharacter/marathon-python:${MARATHONVERSION}"
@@ -29,7 +30,8 @@ script:
 addons:
   hostname: localhost
 
-sudo: required
+os: linux
+dist: xenial
 
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,28 @@
 env:
- - MARATHONVERSION: 1.9.109
- - MARATHONVERSION: 1.6.322
- - MARATHONVERSION: 1.4.11
- - MARATHONVERSION: 1.3.0
- - MARATHONVERSION: 1.1.2
+ - MARATHONVERSION: v1.9.109
+ - MARATHONVERSION: v1.6.322
+ - MARATHONVERSION: v1.4.11
+ - MARATHONVERSION: v1.3.0
+ - MARATHONVERSION: v1.1.2
 
 language: python
+services:
+  - docker
 python:
   - 3.6
   - 3.7
+before_install:
+  - docker pull "missingcharacter/marathon-python:${MARATHONVERSION}"
+  - docker run -d -p 18080:8080 -p 15050:5050 "missingcharacter/marathon-python:${MARATHONVERSION}"
 install:
   - pip install tox
 script:
   - make test
-  - ./itests/install-marathon.sh
-  - ./itests/start-marathon.sh &
   - make itests
 
 # Work around travis-ci/travis-ci#5227
 addons:
   hostname: localhost
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - libstdc++6-4.7-dev
 
 sudo: required
 
@@ -35,5 +33,5 @@ deploy:
       secure: "Wl8GWxsfPy4KoORYH26N3FllvMeWrifzeCbEx2Af4corcBQl43heeiFRRTlUOcSX0TIasER21PUvQ0R0cAgCjfknDb3SOROcRtcSBe16+cMmvwysfxcAx2OcF1UYBPY8e/qOsGge2Zyzx2PAPNEmJoWKbIT3vUJ4WvlLVeGYdJ0="
     on:
       tags: true
-      condition: $MARATHONVERSION == "1.6.322"
+      condition: $MARATHONVERSION == "v1.6.322"
       repo: thefactory/marathon-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,19 @@ services:
 python:
   - 3.6
   - 3.7
+include:
+  - python: 3.7
+    env: TOX_ENV=py37
+  - python: 3.6
+    env: TOX_ENV=py36
 before_install:
   - docker pull "missingcharacter/marathon-python:${MARATHONVERSION}"
-  - docker run -d -p 18080:8080 -p 15050:5050 "missingcharacter/marathon-python:${MARATHONVERSION}"
+  - docker run --name marathon-python -d -p 8080:8080 -p 5050:5050 "missingcharacter/marathon-python:${MARATHONVERSION}"
 install:
   - pip install tox
 script:
-  - make test
-  - make itests
+  - make test-$TOX_ENV
+  - make itests-$TOX_ENV
 
 # Work around travis-ci/travis-ci#5227
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ services:
 python:
   - 3.6
   - 3.7
-jobs:
-  include:
-    - python: 3.7
-      env: TOX_ENV=py37
-    - python: 3.6
-      env: TOX_ENV=py36
 before_install:
   - docker pull "missingcharacter/marathon-python:${MARATHONVERSION}"
   - docker run --name marathon-python -d -p 8080:8080 -p 5050:5050 "missingcharacter/marathon-python:${MARATHONVERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
 install:
   - pip install tox
 script:
-  - make test-$TOX_ENV
-  - make itests-$TOX_ENV
+  - make test-py${TRAVIS_PYTHON_VERSION/./}
+  - make itests-py${TRAVIS_PYTHON_VERSION/./}
 
 # Work around travis-ci/travis-ci#5227
 addons:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-itests:
+itests: itests-py36 itests-py37
+
+itests-py36:
 	tox -e itest-py36
+
+itests-py37:
 	tox -e itest-py37
 
-test:
+test: test-py36 test-py37
+
+test-py36:
 	tox -e pep8
 	tox -e test-py36
+
+test-py37:
 	tox -e test-py37
 
 clean:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make itests
 ### Running The Tests Against a Specific Version of Marathon
 
 ```bash
-MARATHONVERSION=1.6.322 make itests
+MARATHONVERSION=v1.6.322 make itests
 ```
 
 ## Documentation

--- a/itests/.dockerignore
+++ b/itests/.dockerignore
@@ -1,0 +1,66 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+.DS_Store
+
+# IntelliJ
+.idea
+*.iml
+
+# Packer http://packer.io
+packer_cache
+
+/gh-pages
+itests/marathon-version
+.pytest_cache/

--- a/itests/Dockerfile
+++ b/itests/Dockerfile
@@ -1,13 +1,6 @@
-FROM ubuntu:14.04
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-	software-properties-common
-RUN add-apt-repository ppa:webupd8team/java
-RUN echo "debconf shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
-RUN echo "debconf shared/accepted-oracle-license-v1-1 seen true" | debconf-set-selections
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y -q install \
-	lsb-release \
-	oracle-java8-installer
+ARG MARATHONVERSION=v1.6.322
+FROM mesosphere/marathon:$MARATHONVERSION
+USER root
 
 # Setup
 ADD ./marathon-version /root/marathon-version
@@ -16,4 +9,5 @@ RUN /root/install-marathon.sh
 
 EXPOSE 8080 5050
 ADD ./start-marathon.sh /root/start-marathon.sh
-CMD /etc/init.d/zookeeper start && /root/start-marathon.sh
+ENTRYPOINT []
+CMD ["/root/start-marathon.sh"]

--- a/itests/docker-compose.yml
+++ b/itests/docker-compose.yml
@@ -1,6 +1,9 @@
 ---
-marathon:
-  build: .
-  ports:
-    - 18080:8080
-    - 15050:5050
+version: "3.8"
+services:
+  marathon:
+    build:
+      context: .
+    ports:
+      - 18080:8080
+      - 15050:5050

--- a/itests/itest.sh
+++ b/itests/itest.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-[[ -n $TRAVIS ]] || echo MARATHONVERSION=$MARATHONVERSION > marathon-version
-[[ -n $TRAVIS ]] || docker-compose build
+[[ -n $TRAVIS ]] || echo "MARATHONVERSION=${MARATHONVERSION}" > marathon-version
+[[ -n $TRAVIS ]] || docker-compose build --build-arg "MARATHONVERSION=${MARATHONVERSION}"
 [[ -n $TRAVIS ]] || docker-compose pull
 [[ -n $TRAVIS ]] || docker-compose up -d
 behave "$@"

--- a/itests/start-marathon.sh
+++ b/itests/start-marathon.sh
@@ -1,12 +1,29 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -xeuo pipefail
+IFS=$'\n\t'
 
 LOGGER="--logging_level info"
+# Default version of marathon to test against if not set by the user
+[[ -f /root/marathon-version ]] && source /root/marathon-version
+MARATHONVERSION="${MARATHONVERSION:-v1.6.322}"
+
+shopt -s extglob
+
+case "${MARATHONVERSION}" in
+  @(v1.4.11|v1.3.0|v1.1.2))
+    ln -sf /marathon/bin/start /marathon/bin/marathon
+    ;;
+  *)
+    echo "Marathon version ${MARATHONVERSION} needs no specific changes"
+    ;;
+esac
 
 java -version
 export MESOS_WORK_DIR='/tmp/mesos'
-export ZK_HOST=`cat /etc/mesos/zk`
+export ZK_HOST=$(cat /etc/mesos/zk)
 
-mkdir -p "$MESOS_WORK_DIR"
-nohup  mesos-master --work_dir=/tmp/mesosmaster --zk=$ZK_HOST --quorum=1 &
-nohup mesos-agent --master=$ZK_HOST --work_dir=/tmp/mesosagent --launcher=posix &
-exec /usr/bin/marathon --master $ZK_HOST $LOGGER 
+mkdir -p "${MESOS_WORK_DIR}"
+/etc/init.d/zookeeper start
+nohup mesos-master --work_dir=/tmp/mesosmaster --zk=${ZK_HOST} --quorum=1 &> mesos-master.log &
+nohup /usr/bin/env MESOS_SYSTEMD_ENABLE_SUPPORT=false mesos-slave --master=${ZK_HOST} --work_dir=/tmp/mesosagent --launcher=posix &> mesos-agent.log &
+eval "bin/marathon --master ${ZK_HOST} ${LOGGER}"


### PR DESCRIPTION
These changes work locally, I've not tested TravisCI yet.

If you are ok with using pre-built container images, I'd change the tests to build everytime and just pull the images from https://hub.docker.com/r/missingcharacter/marathon-python/tags

It might be a good idea for you guys to create your own repository in hub.docker.com for the images to be pulled from.