### PR TITLE
Use collections.abc where available.

### DIFF
--- a/marathon/util.py
+++ b/marathon/util.py
@@ -1,4 +1,10 @@
-import collections
+# collections.abc new as of 3.3, and collections is deprecated. collections
+# will be unavailable in 3.9
+try:
+    import collections.abc as collections
+except ImportError:
+    import collections
+
 import datetime
 import logging
 


### PR DESCRIPTION
As of Python 3.3 collections.abc should be used in place of collections.
In Python 3.9 use of collections will be removed.